### PR TITLE
Add charts dashboard for key models

### DIFF
--- a/count/trips/templates/base.html
+++ b/count/trips/templates/base.html
@@ -46,6 +46,9 @@
         <li class="nav-item">
           <a class="nav-link" href="{% url 'trips:list' %}">Adelantos</a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{% url 'trips:charts' %}">Gráficos</a>
+        </li>
       </ul>
       {% if user.is_authenticated %}
       <span class="navbar-text me-3">{{ user.email }}</span>

--- a/count/trips/templates/charts/dashboard.html
+++ b/count/trips/templates/charts/dashboard.html
@@ -1,0 +1,79 @@
+{% extends 'base.html' %}
+{% block title %}Gráficos{% endblock %}
+
+{% block content %}
+<h1 class="mb-4">Gráficos</h1>
+<div class="row mb-4">
+  <div class="col-md-6">
+    <canvas id="invoiceChart"></canvas>
+  </div>
+  <div class="col-md-6">
+    <canvas id="tripChart"></canvas>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-6">
+    <canvas id="advanceChart"></canvas>
+  </div>
+  <div class="col-md-6">
+    <canvas id="productChart"></canvas>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ block.super }}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+  const invoiceCtx = document.getElementById('invoiceChart').getContext('2d');
+  new Chart(invoiceCtx, {
+    type: 'bar',
+    data: {
+      labels: {{ invoice_labels|safe }},
+      datasets: [{
+        label: 'Facturación por mes',
+        data: {{ invoice_data|safe }},
+        backgroundColor: 'rgba(54, 162, 235, 0.5)',
+      }]
+    }
+  });
+
+  const tripCtx = document.getElementById('tripChart').getContext('2d');
+  new Chart(tripCtx, {
+    type: 'pie',
+    data: {
+      labels: {{ trip_labels|safe }},
+      datasets: [{
+        data: {{ trip_data|safe }},
+        backgroundColor: ['#36A2EB','#FF6384','#FFCE56','#4BC0C0','#9966FF'],
+      }]
+    }
+  });
+
+  const advanceCtx = document.getElementById('advanceChart').getContext('2d');
+  new Chart(advanceCtx, {
+    type: 'bar',
+    data: {
+      labels: {{ advance_labels|safe }},
+      datasets: [{
+        label: 'Adelantos por categoría',
+        data: {{ advance_data|safe }},
+        backgroundColor: 'rgba(75, 192, 192, 0.5)',
+      }]
+    }
+  });
+
+  const productCtx = document.getElementById('productChart').getContext('2d');
+  new Chart(productCtx, {
+    type: 'bar',
+    data: {
+      labels: {{ product_labels|safe }},
+      datasets: [{
+        label: 'Precio por kilo',
+        data: {{ product_data|safe }},
+        backgroundColor: 'rgba(153, 102, 255, 0.5)',
+      }]
+    }
+  });
+</script>
+{% endblock %}

--- a/count/trips/urls.py
+++ b/count/trips/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path("", TripListView.as_view(), name="trip_list"),
     path("ajax/get_vehicles_by_driver/", views.get_vehicles_by_driver, name="get_vehicles_by_driver"),
     path("ajax/get_product_price/", views.get_product_price, name="get_product_price"),
+    path("charts/", views.charts_view, name="charts"),
 
     
     # Viajes


### PR DESCRIPTION
## Summary
- add charts dashboard showing summaries for invoices, trips, driver advances and products
- link new dashboard from main navigation

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689df6f252508329b9bf0122854cd6a2