### PR TITLE
Add Carta de Porte retrieval via CGT

### DIFF
--- a/count/trips/forms.py
+++ b/count/trips/forms.py
@@ -8,6 +8,7 @@ from django.core.exceptions import ValidationError
 import logging
 from django.forms import modelformset_factory
 import datetime
+from django.db.models import Q
 from .fact_arca import emitir_factura_dinamica
 
 
@@ -388,3 +389,16 @@ DriverAdvanceFormSet = modelformset_factory(
     extra=1,
     can_delete=True
 )
+
+
+class CartaPorteForm(forms.Form):
+    invoice = forms.ModelChoiceField(queryset=Invoice.objects.none(), label="Factura")
+    ctg = forms.CharField(label="Número CTG")
+
+    def __init__(self, *args, client=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        if client:
+            self.fields["invoice"].queryset = Invoice.objects.filter(
+                Q(trip__client=client) | Q(trip__isnull=True)
+            )
+

--- a/count/trips/models.py
+++ b/count/trips/models.py
@@ -199,9 +199,11 @@ class Invoice(models.Model):
 
     # Nuevos campos AFIP
     punto_venta = models.PositiveIntegerField(default=1)
-    tipo_cbte = models.PositiveIntegerField(default=6)  
+    tipo_cbte = models.PositiveIntegerField(default=6)
     cae = models.CharField(max_length=14, blank=True, null=True)
     cae_vencimiento = models.DateField(blank=True, null=True)
+    carta_porte_ctg = models.CharField(max_length=20, blank=True, null=True)
+    carta_porte_pdf = models.BinaryField(blank=True, null=True)
 
     def paid_total(self):
         return sum(p.amount for p in self.payments.all())

--- a/count/trips/templates/trips/carta_porte_form.html
+++ b/count/trips/templates/trips/carta_porte_form.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% load widget_tweaks %}
+
+{% block title %}Vincular Carta de Porte{% endblock %}
+
+{% block content %}
+<div class="container mt-5">
+  <div class="row justify-content-center">
+    <div class="col-md-8 col-lg-6">
+      <h3 class="mb-4 text-center">Carta de Porte para {{ client }}</h3>
+      <form method="post" class="card shadow-sm p-4 bg-light border-0 rounded">
+        {% csrf_token %}
+        {% for field in form %}
+        <div class="mb-3">
+          <label for="{{ field.id_for_label }}" class="form-label">{{ field.label }}</label>
+          {% render_field field class="form-control" %}
+          {% for error in field.errors %}
+            <div class="text-danger small">{{ error }}</div>
+          {% endfor %}
+        </div>
+        {% endfor %}
+        <div class="d-flex justify-content-end gap-2">
+          <button type="submit" name="action" value="link" class="btn btn-success">Guardar</button>
+          <button type="submit" name="action" value="create_trip" class="btn btn-primary">Generar viaje</button>
+          <a href="{% url 'trips:invoice_list' %}" class="btn btn-secondary">Cancelar</a>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/count/trips/test_carta_porte.py
+++ b/count/trips/test_carta_porte.py
@@ -1,0 +1,34 @@
+from django.test import SimpleTestCase
+from unittest.mock import patch, ANY
+from trips.fact_arca import obtener_carta_porte, WSDL_CGT
+import base64
+
+
+class CartaPorteTests(SimpleTestCase):
+    def test_obtener_carta_porte_parses_response(self):
+        sample = {
+            "estado": "vigente",
+            "origen": "Buenos Aires",
+            "destino": "Córdoba",
+            "patente": "ABC123",
+            "pdf": base64.b64encode(b"fake-pdf").decode(),
+        }
+
+        with patch("trips.fact_arca.Client") as mock_client, \
+             patch("trips.fact_arca.obtener_token_sign_desde_cache", return_value=("tok", "sig")):
+            mock_client.return_value.service.consultarCTG.return_value = sample
+
+            resp = obtener_carta_porte(123)
+
+            mock_client.assert_called_once_with(WSDL_CGT, transport=ANY)
+            mock_client.return_value.service.consultarCTG.assert_called_once()
+            self.assertEqual(
+                resp,
+                {
+                    "estado": "vigente",
+                    "origen": "Buenos Aires",
+                    "destino": "Córdoba",
+                    "patente": "ABC123",
+                    "pdf": b"fake-pdf",
+                },
+            )

--- a/count/trips/test_carta_porte_view.py
+++ b/count/trips/test_carta_porte_view.py
@@ -1,0 +1,69 @@
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.contrib.auth.models import User
+from unittest.mock import patch
+from django.core import mail
+
+from .models import Client, Driver, Vehicle, Product, Trip, Invoice
+
+
+class CartaPorteViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="u", password="p")
+        self.client.login(username="u", password="p")
+        self.client_obj = Client.objects.create(nombre="Tester", gmail="t@test.com")
+        self.driver = Driver.objects.create(name="D")
+        self.vehicle = Vehicle.objects.create(plate="ABC123", driver=self.driver)
+        self.product = Product.objects.create(
+            name="Prod", price_per_kilo=1, volume=1, trailer_category="flatbed"
+        )
+        self.trip = Trip.objects.create(
+            client=self.client_obj,
+            driver=self.driver,
+            vehicle=self.vehicle,
+            product=self.product,
+            start_address="A",
+            end_address="B",
+            total_weight=1,
+            value=100,
+        )
+        self.invoice = Invoice.objects.create(trip=self.trip, amount=100)
+        self.invoice_no_trip = Invoice.objects.create(amount=50)
+
+    @override_settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend')
+    @patch('trips.views.obtener_carta_porte')
+    def test_links_invoice_and_sends_mail(self, mock_obtener):
+        mock_obtener.return_value = {
+            "estado": "v", "origen": "o", "destino": "d", "patente": "p", "pdf": b"pdf"
+        }
+        url = reverse('trips:carta_porte_invoice', args=[self.client_obj.id])
+        data = {"invoice": self.invoice.id, "ctg": "123"}
+        response = self.client.post(url, data, follow=True)
+        self.assertRedirects(response, reverse('trips:invoice_detail', args=[self.invoice.id]))
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.carta_porte_ctg, "123")
+        self.assertEqual(self.invoice.carta_porte_pdf, b"pdf")
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertTrue(mail.outbox[0].attachments)
+
+    @override_settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend')
+    @patch('trips.views.obtener_carta_porte')
+    def test_creates_trip_from_carta_porte(self, mock_obtener):
+        mock_obtener.return_value = {
+            "estado": "v", "origen": "o", "destino": "d", "patente": "ABC123", "pdf": b"pdf"
+        }
+        url = reverse('trips:carta_porte_invoice', args=[self.client_obj.id])
+        data = {"invoice": self.invoice_no_trip.id, "ctg": "123", "action": "create_trip"}
+        response = self.client.post(url, data, follow=True)
+        self.assertRedirects(response, reverse('trips:invoice_detail', args=[self.invoice_no_trip.id]))
+        self.invoice_no_trip.refresh_from_db()
+        trip = self.invoice_no_trip.trip
+        self.assertIsNotNone(trip)
+        self.assertEqual(trip.start_address, "o")
+        self.assertEqual(trip.end_address, "d")
+        self.assertEqual(trip.status, "recibido")
+        self.assertEqual(trip.vehicle, self.vehicle)
+        self.assertEqual(trip.driver, self.driver)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertTrue(mail.outbox[0].attachments)
+

--- a/count/trips/urls.py
+++ b/count/trips/urls.py
@@ -44,6 +44,7 @@ urlpatterns = [
     path("clients/new/", views.client_create, name="client_create"),
     path("clientes/<int:pk>/editar/", views.client_update, name="client_update"),
     path("clients/<int:cliente_id>/asesoramiento/", views.asesoramiento_create, name="asesoramiento_create"),
+    path("clients/<int:client_id>/carta-porte/", views.carta_porte_invoice, name="carta_porte_invoice"),
 
     # Conductores
     path("drivers/", DriverListView.as_view(), name="drivers_list"),


### PR DESCRIPTION
## Summary
- add WSDL constant and helper to query CGT Carta de Porte service
- parse CGT responses to extract status, origin, destination, license plate and PDF
- link invoices to Carta de Porte and email the PDF to the client
- allow generating trips in 'recibido' status from Carta de Porte data

## Testing
- `python manage.py migrate`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a89ce84ad8832987cca97f3c202d64