### PR TITLE
Allow creating drivers without advances

### DIFF
--- a/count/trips/forms.py
+++ b/count/trips/forms.py
@@ -291,16 +291,18 @@ class DriverAdvanceForm(forms.ModelForm):
     )
 
     category = forms.ChoiceField(
-        choices=DriverAdvance.AdvanceCategory.choices,
+        choices=[("", "---------")] + list(DriverAdvance.AdvanceCategory.choices),
         label="Categoría",
-        widget=forms.Select(attrs={"class": "form-select"})
+        widget=forms.Select(attrs={"class": "form-select"}),
+        required=False,
     )
 
     amount = forms.DecimalField(
         label="Monto",
         max_digits=10,
         decimal_places=2,
-        widget=forms.NumberInput(attrs={"class": "form-control", "placeholder": "Ej. 5000.00"})
+        widget=forms.NumberInput(attrs={"class": "form-control", "placeholder": "Ej. 5000.00"}),
+        required=False,
     )
 
     description = forms.CharField(
@@ -312,6 +314,20 @@ class DriverAdvanceForm(forms.ModelForm):
     class Meta:
         model = DriverAdvance
         fields = ["driver", "category", "amount", "description"]
+
+    def clean(self):
+        cleaned_data = super().clean()
+        category = cleaned_data.get("category")
+        amount = cleaned_data.get("amount")
+        description = cleaned_data.get("description")
+
+        if category or amount or description:
+            if not category:
+                self.add_error("category", "Este campo es obligatorio.")
+            if not amount:
+                self.add_error("amount", "Este campo es obligatorio.")
+
+        return cleaned_data
 
 
 class DriverAdvanceFormCreate(forms.ModelForm):

--- a/count/trips/tests.py
+++ b/count/trips/tests.py
@@ -16,6 +16,7 @@ from trips.models import (
     Product,
     Trip,
     Trailer,
+    DriverAdvance,
 )
 
 class ValidatePlateTests(TestCase):
@@ -204,6 +205,25 @@ class DriverCreateViewTests(TestCase):
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, 302)
         self.assertTrue(Driver.objects.filter(name="John").exists())
+
+    def test_can_create_driver_with_empty_advance_form(self):
+        self.client.force_login(self.user)
+        url = reverse("trips:driver_create")
+        data = {
+            "name": "Max",
+            **self._formset_data("addresses"),
+            **self._formset_data("advances"),
+        }
+        data["advances-TOTAL_FORMS"] = "1"
+        data["advances-0-id"] = ""
+        data["advances-0-driver"] = ""
+        data["advances-0-category"] = ""
+        data["advances-0-amount"] = ""
+        data["advances-0-description"] = ""
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(Driver.objects.filter(name="Max").exists())
+        self.assertEqual(DriverAdvance.objects.count(), 0)
 
     def test_invalid_driver_prints_errors(self):
         self.client.force_login(self.user)


### PR DESCRIPTION
## Summary
- Permit empty advance forms when creating drivers
- Add regression test for optional advances

## Testing
- `python manage.py test` *(fails: table trips_driver has no column named license_front_image)*

------
https://chatgpt.com/codex/tasks/task_e_68abcb190d008329affb3cc3390cd966