### PR TITLE
Permitir Carta de Porte sin factura vinculada

### DIFF
--- a/count/count/test_settings.py
+++ b/count/count/test_settings.py
@@ -13,6 +13,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'trips',
+    'widget_tweaks',
 ]
 
 MIGRATION_MODULES = {

--- a/count/trips/forms.py
+++ b/count/trips/forms.py
@@ -455,7 +455,9 @@ DriverAdvanceFormSet = modelformset_factory(
 
 
 class CartaPorteForm(forms.Form):
-    invoice = forms.ModelChoiceField(queryset=Invoice.objects.none(), label="Factura")
+    invoice = forms.ModelChoiceField(
+        queryset=Invoice.objects.none(), label="Factura", required=False
+    )
     ctg = forms.CharField(label="Número CTG")
 
     def __init__(self, *args, client=None, **kwargs):


### PR DESCRIPTION
- Hacer opcional la selección de factura al generar una Carta de Porte
- Ajustar vista para crear Carta de Porte sin factura y redirigir al listado de viajes
- Agregar prueba que cubre la ausencia de factura y actualizar configuración de tests

